### PR TITLE
config(nixpkgs): Switch nixpkgs input from `nixos-22.05` to `release-22.05`

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -62,16 +62,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1654360807,
-        "narHash": "sha256-wYG86PUkPZ1P/oHsCpepTkb/U26poaEPPp1XFjRsgdA=",
+        "lastModified": 1654781711,
+        "narHash": "sha256-3WUEsmMxeqBZAQiA/jrtmL+2cNeNsxQhkRbOD+D8Mrg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d9794b04bffb468b886c553557489977ae5f4c65",
+        "rev": "41f240fe872329b53bbdc8c7687d633842394788",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "release-22.05",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/release-22.05";
 
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 


### PR DESCRIPTION
Needed while waiting for the discord app version bump to trickle down to the stable channel:
https://nixpk.gs/pr-tracker.html?pr=176957