### PR TITLE
feat(flake): Upgrade to NixOS 22.11 and update all Flake inputs (2022-12-08)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -4,19 +4,20 @@
       "inputs": {
         "nixpkgs": [
           "nixpkgs"
-        ]
+        ],
+        "utils": "utils"
       },
       "locked": {
-        "lastModified": 1667677389,
-        "narHash": "sha256-y9Zdq8vtsn0T5TO1iTvWA7JndYIAGjzCjbYVi/hOSmA=",
+        "lastModified": 1670253003,
+        "narHash": "sha256-/tJIy4+FbsQyslq1ipyicZ2psOEd8dvl4OJ9lfisjd0=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "87d55517f6f36aa1afbd7a4a064869d5a1d405b8",
+        "rev": "0e8125916b420e41bf0d23a0aa33fadd0328beb3",
         "type": "github"
       },
       "original": {
         "owner": "nix-community",
-        "ref": "release-22.05",
+        "ref": "release-22.11",
         "repo": "home-manager",
         "type": "github"
       }
@@ -47,16 +48,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667653703,
-        "narHash": "sha256-Xow4vx52/g5zkhlgZnMEm/TEXsj+13jTPCc2jIhW1xU=",
+        "lastModified": 1670372410,
+        "narHash": "sha256-BDiOUkuqgq5DP+E5xfTzIFYYyMb8DpSLYmeaOBeZ0vg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f09ad462c5a121d0239fde645aacb2221553a217",
+        "rev": "5528350186a9e826588cee1329640899ca44a0cf",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.05",
+        "ref": "nixos-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -116,6 +117,21 @@
         "nixpkgs": "nixpkgs",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "omf-bobthefish": "omf-bobthefish"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -7,12 +7,12 @@
   };
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.05";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
 
     nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
 
     home-manager = {
-      url = "github:nix-community/home-manager/release-22.05";
+      url = "github:nix-community/home-manager/release-22.11";
       inputs.nixpkgs.follows = "nixpkgs";
     };
 
@@ -57,9 +57,17 @@
 
     makeHomeConfig = username:
       home-manager.lib.homeManagerConfiguration {
-        inherit system username;
-        homeDirectory = "/home/${username}";
-        configuration = import ./nixos/home/home.nix;
+        inherit pkgs;
+        modules = [
+          ./nixos/home/home.nix
+          {
+            home = {
+              inherit username;
+              homeDirectory = "/home/${username}";
+              stateVersion = "21.11";
+            };
+          }
+        ];
         extraSpecialArgs = {
           inherit omf-bobthefish;
           unstablePkgs = import nixpkgs-unstable {
@@ -67,7 +75,6 @@
             config = {allowUnfree = true;};
           };
         };
-        stateVersion = "21.11";
       };
 
     makeNixOnDroidConfig = username:

--- a/nixos/sys/nix.nix
+++ b/nixos/sys/nix.nix
@@ -5,9 +5,9 @@
 }: {
   nix = {
     package = pkgs.nixVersions.stable;
-    trustedUsers = ["root" defaultUser];
-    extraOptions = ''
-      experimental-features = nix-command flakes
-    '';
+    settings = {
+      trusted-users = ["root" defaultUser];
+      experimental-features = ["nix-command" "flakes"];
+    };
   };
 }

--- a/nixos/sys/virtualisation.nix
+++ b/nixos/sys/virtualisation.nix
@@ -1,5 +1,9 @@
-{
+{config, ...}: {
   virtualisation.docker.enable = true;
+  virtualisation.docker.storageDriver =
+    if config.fileSystems ? "/var/lib/docker" && config.fileSystems."/var/lib/docker".fsType == "zfs"
+    then "zfs"
+    else "overlay2";
   virtualisation.libvirtd.enable = true;
 
   boot.extraModprobeConfig = ''


### PR DESCRIPTION
And also:

* config(nixos/programs): Enable `programs.gnupg.agent` 
* config(nixos/home/fish): Add `foreign-env` plugin
* config(machines/mcl-nixos-desktop01): Disable GDM auto suspend
* config(machines/mcl-nixos-desktop01): Disable systemd sleep & suspend targets
* config(sys/virtualisation): Use ZFS or Overlay2 as the docker storage backend