### PR TITLE
chore(flake.lock): Update all Flake inputs (2023-07-31)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,11 +110,11 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1688144254,
-        "narHash": "sha256-8KL1l/7eP2Zm1aJjdVaSOk0W5kTnJo9kcgW03gqWuiI=",
+        "lastModified": 1690468281,
+        "narHash": "sha256-8qqM6X+FZv5LM/m9q+B8DmlaCQNjXKKVTaU2n2Nlr2I=",
         "owner": "t184256",
         "repo": "nix-on-droid",
-        "rev": "2301e01d48c90b60751005317de7a84a51a87eb6",
+        "rev": "b324ef282494280f463a4f549e10363e6abdfdb1",
         "type": "github"
       },
       "original": {
@@ -133,11 +133,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1690389899,
-        "narHash": "sha256-IZ8N++v1DMpQ0RGWzo+QFBZKtdPsLrAFlCzpgMqZsrg=",
+        "lastModified": 1690805527,
+        "narHash": "sha256-CGAiP0bPPDdsbYQdfAPYl3lIMQbJuyxG4tzGgU1BKUE=",
         "owner": "nix-community",
         "repo": "nixd",
-        "rev": "c080d75976bdd77e2ab9cf1fdb003771ac4db4ec",
+        "rev": "c4f71ee237124c41313e9c13a1b2c033ed26f70c",
         "type": "github"
       },
       "original": {
@@ -148,11 +148,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1690370995,
-        "narHash": "sha256-9z//23jGegLJrf3ITStLwVf715O39dq5u48Kr/XW14U=",
+        "lastModified": 1690630041,
+        "narHash": "sha256-gbnvqm5goS9DSKAqGFpq3398aOpwejmq4qWikqmQyRo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f3fbbc36b4e179a5985b9ab12624e9dfe7989341",
+        "rev": "d57e8c535d4cbb07f441c30988ce52eec69db7a8",
         "type": "github"
       },
       "original": {
@@ -180,11 +180,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1690272529,
-        "narHash": "sha256-MakzcKXEdv/I4qJUtq/k/eG+rVmyOZLnYNC2w1mB59Y=",
+        "lastModified": 1690640159,
+        "narHash": "sha256-5DZUYnkeMOsVb/eqPYb9zns5YsnQXRJRC8Xx/nPMcno=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ef99fa5c5ed624460217c31ac4271cfb5cb2502c",
+        "rev": "e6ab46982debeab9831236869539a507f670a129",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
• Updated input 'nix-on-droid':
    'github:t184256/nix-on-droid/2301e01d48c90b60751005317de7a84a51a87eb6' (2023-06-30)
  → 'github:t184256/nix-on-droid/b324ef282494280f463a4f549e10363e6abdfdb1' (2023-07-27)
• Updated input 'nixd':
    'github:nix-community/nixd/c080d75976bdd77e2ab9cf1fdb003771ac4db4ec' (2023-07-26)
  → 'github:nix-community/nixd/c4f71ee237124c41313e9c13a1b2c033ed26f70c' (2023-07-31)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/f3fbbc36b4e179a5985b9ab12624e9dfe7989341' (2023-07-26)
  → 'github:NixOS/nixpkgs/d57e8c535d4cbb07f441c30988ce52eec69db7a8' (2023-07-29)
• Updated input 'nixpkgs-unstable':
    'github:NixOS/nixpkgs/ef99fa5c5ed624460217c31ac4271cfb5cb2502c' (2023-07-25)
  → 'github:NixOS/nixpkgs/e6ab46982debeab9831236869539a507f670a129' (2023-07-29)
