### PR TITLE
feat(nix-on-droid): Add initial working flake-based config

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -110,15 +110,16 @@
         "nmd": "nmd_2"
       },
       "locked": {
-        "lastModified": 1694604941,
-        "narHash": "sha256-KsoRStRs8dNRRMWQhuB3eUOpzQhOc4dcBQB85tEq3wY=",
-        "owner": "t184256",
+        "lastModified": 1688144254,
+        "narHash": "sha256-8KL1l/7eP2Zm1aJjdVaSOk0W5kTnJo9kcgW03gqWuiI=",
+        "owner": "nix-community",
         "repo": "nix-on-droid",
-        "rev": "039379abeee67144d4094d80bbdaf183fb2eabe5",
+        "rev": "2301e01d48c90b60751005317de7a84a51a87eb6",
         "type": "github"
       },
       "original": {
-        "owner": "t184256",
+        "owner": "nix-community",
+        "ref": "release-23.05",
         "repo": "nix-on-droid",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,7 @@
     };
 
     nix-on-droid = {
-      url = "github:t184256/nix-on-droid";
+      url = "github:nix-community/nix-on-droid/release-23.05";
       inputs = {
         nixpkgs.follows = "nixpkgs";
         home-manager.follows = "home-manager";

--- a/flake.nix
+++ b/flake.nix
@@ -53,13 +53,10 @@
     flake-parts.lib.mkFlake {inherit inputs;} {
       systems = ["x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin"];
       _module.args = {inherit defaultUser;};
-      imports = [./nixos/machines];
-      flake = {
-        nixOnDroidConfigurations.device = nix-on-droid.lib.nixOnDroidConfiguration {
-          config = ./nix-on-droid.nix;
-          system = "aarch64-linux";
-        };
-      };
+      imports = [
+        ./nixos/machines
+        ./nixos/nix-on-droid
+      ];
       perSystem = {
         pkgs,
         unstablePkgs,

--- a/nixos/home/base/git.nix
+++ b/nixos/home/base/git.nix
@@ -1,11 +1,7 @@
 {pkgs, ...}: {
   programs.git = {
     enable = true;
-    package = pkgs.git.override {
-      withSsh = true;
-      withLibsecret = true;
-      sendEmailSupport = true;
-    };
+    package = pkgs.gitFull;
     delta.enable = true;
     includes = [
       {path = ../../../.gitconfig;}

--- a/nixos/home/base/home.nix
+++ b/nixos/home/base/home.nix
@@ -1,15 +1,23 @@
 {
   config,
   pkgs,
-  username,
+  lib,
   ...
-}: {
+} @ args: let
+  username =
+    if args ? username
+    then args.username
+    else "!";
+in {
   home = {
-    inherit username;
+    username = lib.mkIf (args ? username) username;
     homeDirectory =
-      if pkgs.hostPlatform.isDarwin
-      then "/Users/${username}"
-      else "/home/${username}";
+      lib.mkIf (args ? username)
+      (
+        if pkgs.hostPlatform.isDarwin
+        then "/Users/${username}"
+        else "/home/${username}"
+      );
     stateVersion = "22.11";
   };
 

--- a/nixos/home/base/pkg-sets/cli-utils.nix
+++ b/nixos/home/base/pkg-sets/cli-utils.nix
@@ -5,14 +5,38 @@
   ...
 }: {
   home.packages = with pkgs; [
+    # foundational tools
+    which
+    findutils
+    gnugrep
+    utillinux
+    diffutils
+    curl
+    htop
+    ncurses
+    tzdata
+    hostname
+    man
+    gnused
+    gnutar
+    bzip2
+    gzip
+    xz
+    zip
+    unzip
+
+    # crypto-related
+    gnupg
+    openssh
+    openssl
+
+    # icing
     bat
     ripgrep
     gitAndTools.diff-so-fancy
     jq
     yq
-    curl
     tree
-    htop
     rage
     gh
     age-plugin-yubikey

--- a/nixos/home/base/pkg-sets/cli-utils.nix
+++ b/nixos/home/base/pkg-sets/cli-utils.nix
@@ -14,6 +14,7 @@
     tree
     htop
     rage
+    gh
     age-plugin-yubikey
   ];
 

--- a/nixos/home/full/pkg-sets/cli-utils.nix
+++ b/nixos/home/full/pkg-sets/cli-utils.nix
@@ -1,7 +1,6 @@
 {pkgs, ...}: {
   home.packages = with pkgs; [
     asciinema
-    gh
     # qrencode
     # w3m
   ];

--- a/nixos/nix-on-droid/default.nix
+++ b/nixos/nix-on-droid/default.nix
@@ -1,0 +1,52 @@
+{
+  withSystem,
+  inputs,
+  ...
+}: {
+  flake.nixOnDroidConfigurations = {
+    default = withSystem "aarch64-linux" (
+      {inputs', ...}: let
+        pkgs = import inputs.nixpkgs {
+          system = "aarch64-linux";
+          overlays = [inputs.nix-on-droid.overlays.default];
+        };
+
+        unstablePkgs = import inputs.nixpkgs-unstable {
+          system = "aarch64-linux";
+          overlays = [inputs.nix-on-droid.overlays.default];
+        };
+      in
+        inputs.nix-on-droid.lib.nixOnDroidConfiguration {
+          inherit pkgs;
+
+          modules = [
+            ({config, ...}: {
+              system.stateVersion = "23.05";
+              environment.etcBackupExtension = ".bak";
+              time.timeZone = "Europe/Sofia";
+              nix.extraOptions = ''
+                experimental-features = nix-command flakes
+              '';
+              user.shell = "${pkgs.fish}/bin/fish";
+              home-manager = {
+                config = ../home/base;
+                backupFileExtension = "hm-bak";
+                useGlobalPkgs = true;
+                extraSpecialArgs = {
+                  inherit unstablePkgs inputs inputs';
+                };
+              };
+            })
+
+            # { nix.registry.nixpkgs.flake = nixpkgs; }
+          ];
+
+          extraSpecialArgs = {
+            inherit unstablePkgs inputs inputs';
+          };
+
+          home-manager-path = inputs.home-manager.outPath;
+        }
+    );
+  };
+}


### PR DESCRIPTION
- refactor(home/{base,full}): Move `gh` pkg from full to base
- config(nixos/home/base/git): Switch to using `gitFull` package
- refactor(home/base/home): Make `username` extraSpecialArg optional
- build(flake.nix/inputs): Specify `nix-on-droid` branch compatible with nixos-23.05
- feat(nix-on-droid): Add first working flakes-based config
