### PR TITLE
add_pkgs: eza & lunarvim

### DIFF
--- a/nixos/home/base/pkg-sets/cli-utils.nix
+++ b/nixos/home/base/pkg-sets/cli-utils.nix
@@ -40,6 +40,7 @@
     rage
     gh
     age-plugin-yubikey
+    lunarvim
   ];
 
   programs.eza = {

--- a/nixos/home/base/pkg-sets/cli-utils.nix
+++ b/nixos/home/base/pkg-sets/cli-utils.nix
@@ -44,9 +44,16 @@
 
   programs.eza = {
     enable = true;
+    enableAliases = true;
     icons = true;
     git = true;
-    extraOptions = ["--group-directories-first"];
+    extraOptions = [
+      "--group-directories-first"
+      "--header"
+      "--hyperlink"
+      "--color-scale"
+      "--binary"
+    ];
   };
 
   programs.zellij = {

--- a/nixos/home/base/pkg-sets/cli-utils.nix
+++ b/nixos/home/base/pkg-sets/cli-utils.nix
@@ -42,7 +42,7 @@
     age-plugin-yubikey
   ];
 
-  programs.exa = {
+  programs.eza = {
     enable = true;
     icons = true;
     git = true;

--- a/nixos/sys/packages.nix
+++ b/nixos/sys/packages.nix
@@ -12,7 +12,7 @@
     nodejsPackage = pkgs.nodejs;
   };
 
-  fonts.fonts = with pkgs; [
+  fonts.packages = with pkgs; [
     (nerdfonts.override {fonts = ["DroidSansMono" "FiraCode" "FiraMono"];})
   ];
 


### PR DESCRIPTION
- config(nixos/home/base/pkg-sets/cli-utils): Replaces unmaintained `exa` with `eza`
- config(nixos/home/base/pkg-sets/cli-utils): Add extra `eza` options and enable aliases
- add_pkg(ome/base/pkg-sets/cli-utils): `lunarvim`
